### PR TITLE
Updated for MongoMapper 0.11.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Basic MongoMapper port of technoweenie's [acts_as_versioned](http://github.com/technoweenie/acts_as_versioned). Stores changed attributes in a Hash key inside an Embedded Document instead of copying all keys from the original model.
 
-*Note:* This plugin is intended for MongoMapper 0.8.6. The plugin architecture must be slightly changed for it to work on 0.9+.
-
 ## Usage
 
 ### Basic Example
@@ -55,7 +53,7 @@ Simply add `self.non_versioned_keys << 'new_skipped_key'` somewhere in your mode
 
 ## Tested with
 
-* MongoMapper 0.8.3
+* MongoMapper 0.11.1
 * Ruby 1.9.2
 
 ## TODO

--- a/README.md
+++ b/README.md
@@ -61,10 +61,6 @@ Simply add `self.non_versioned_keys << 'new_skipped_key'` somewhere in your mode
 * Add loads more options
 * Properly document those options
 
-## Bundler note
-
-Make sure to specify `:require => 'acts_as_versioned'` in your Gemfile.
-
 ## Copyright
 
 Copyright (c) 2010 Gigamo &lt;gigamo@gmail.com&gt;. See LICENSE for details.

--- a/lib/acts_as_versioned.rb
+++ b/lib/acts_as_versioned.rb
@@ -1,4 +1,4 @@
-require 'active_support/concern'
+require_relative 'active_support/concern'
 
 module MongoMapper
   module Acts

--- a/lib/acts_as_versioned.rb
+++ b/lib/acts_as_versioned.rb
@@ -1,11 +1,11 @@
-require 'active_support/concern'
+require 'active_support/core_ext'
 
 module MongoMapper
   module Acts
     module Versioned
       extend ActiveSupport::Concern
 
-      VERSION   = '0.1.4'
+      VERSION   = '0.1.5'
       CALLBACKS = [:save_version, :clear_old_versions]
 
       included do

--- a/lib/acts_as_versioned.rb
+++ b/lib/acts_as_versioned.rb
@@ -96,7 +96,7 @@ module MongoMapper
           end
 
           self.class.versioned_keys.each do |attribute|
-            new_model[attribute] = orig_model[attribute].to_mongo
+            new_model[attribute] = escape_mongo(orig_model[attribute])
           end
         end
 
@@ -109,6 +109,10 @@ module MongoMapper
         end
 
         def empty_callback
+        end
+        
+        def escape_mongo(obj)
+          obj.is_a?(MongoMapper::Extensions::Date) || obj.is_a?(MongoMapper::Extensions::Time) ? Date.to_mongo(obj) : obj
         end
 
       protected

--- a/lib/acts_as_versioned.rb
+++ b/lib/acts_as_versioned.rb
@@ -1,4 +1,4 @@
-require_relative 'active_support/concern'
+require 'active_support/concern'
 
 module MongoMapper
   module Acts

--- a/lib/acts_as_versioned.rb
+++ b/lib/acts_as_versioned.rb
@@ -1,41 +1,41 @@
+require 'active_support/concern'
+
 module MongoMapper
   module Acts
     module Versioned
       extend ActiveSupport::Concern
 
-      VERSION   = '0.1.0'
+      VERSION   = '0.1.1'
       CALLBACKS = [:save_version, :clear_old_versions]
 
-      def self.configure(model)
-        model.class_eval do
-          cattr_accessor :versioned_class_name,
-            :non_versioned_keys, :max_version_limit
+      included do
+        cattr_accessor :versioned_class_name,
+          :non_versioned_keys, :max_version_limit
 
-          self.versioned_class_name = :Version
-          self.max_version_limit    = 0
-          self.non_versioned_keys   = %w[
-            _id _type created_at updated_at
-            creator_id updater_id version
-          ]
+        self.versioned_class_name = :Version
+        self.max_version_limit    = 0
+        self.non_versioned_keys   = %w[
+          _id _type created_at updated_at
+          creator_id updater_id version
+        ]
 
-          const_set(versioned_class_name, Class.new).class_eval do
-            include MongoMapper::EmbeddedDocument
+        const_set(versioned_class_name, Class.new).class_eval do
+          include MongoMapper::EmbeddedDocument
 
-            key :version,  Integer
-            key :modified, Hash
-          end
-
-          class_name = "#{self}::#{versioned_class_name}"
-          many :versions, :class => class_name.constantize do
-            def [](version)
-              detect { |doc| doc.version.to_s == version.to_s }
-            end
-          end
-
-          key :version, Integer
-          before_save :save_version
-          before_save :clear_old_versions
+          key :version,  Integer
+          key :modified, Hash
         end
+
+        class_name = "#{self}::#{versioned_class_name}"
+        many :versions, :class => class_name.constantize do
+          def [](version)
+            detect { |doc| doc.version.to_s == version.to_s }
+          end
+        end
+
+        key :version, Integer
+        before_save :save_version
+        before_save :clear_old_versions
       end
 
       module InstanceMethods

--- a/lib/acts_as_versioned.rb
+++ b/lib/acts_as_versioned.rb
@@ -1,6 +1,8 @@
 module MongoMapper
   module Acts
     module Versioned
+      extend ActiveSupport::Concern
+
       VERSION   = '0.1.0'
       CALLBACKS = [:save_version, :clear_old_versions]
 

--- a/lib/acts_as_versioned.rb
+++ b/lib/acts_as_versioned.rb
@@ -5,7 +5,7 @@ module MongoMapper
     module Versioned
       extend ActiveSupport::Concern
 
-      VERSION   = '0.1.1'
+      VERSION   = '0.1.2'
       CALLBACKS = [:save_version, :clear_old_versions]
 
       included do
@@ -112,7 +112,7 @@ module MongoMapper
         end
         
         def escape_mongo(obj)
-          obj.is_a?(MongoMapper::Extensions::Date) || obj.is_a?(MongoMapper::Extensions::Time) ? Date.to_mongo(obj) : obj
+          obj.is_a?(Date) || obj.is_a?(Time) ? Date.to_mongo(obj) : obj
         end
 
       protected

--- a/lib/acts_as_versioned.rb
+++ b/lib/acts_as_versioned.rb
@@ -1,4 +1,4 @@
-require_relative 'active_support/concern'
+# require_relative 'active_support/concern'
 
 module MongoMapper
   module Acts

--- a/lib/acts_as_versioned.rb
+++ b/lib/acts_as_versioned.rb
@@ -5,7 +5,7 @@ module MongoMapper
     module Versioned
       extend ActiveSupport::Concern
 
-      VERSION   = '0.1.0'
+      VERSION   = '0.1.1'
       CALLBACKS = [:save_version, :clear_old_versions]
 
       included do

--- a/lib/acts_as_versioned.rb
+++ b/lib/acts_as_versioned.rb
@@ -1,4 +1,4 @@
-# require_relative 'active_support/concern'
+require_relative 'active_support/concern'
 
 module MongoMapper
   module Acts

--- a/lib/acts_as_versioned.rb
+++ b/lib/acts_as_versioned.rb
@@ -47,11 +47,7 @@ module MongoMapper
             clone_attributes(self, rev)
             rev.version = version
 
-            begin
-              self.versions << rev
-              self.save
-            rescue BSON::InvalidDocument => e
-            end
+            self.versions << rev
           end
         end
 

--- a/lib/acts_as_versioned.rb
+++ b/lib/acts_as_versioned.rb
@@ -1,4 +1,4 @@
-require 'active_support'
+require 'active_support/concern'
 
 module MongoMapper
   module Acts

--- a/lib/acts_as_versioned.rb
+++ b/lib/acts_as_versioned.rb
@@ -1,4 +1,4 @@
-require 'active_support/concern'
+require 'active_support'
 
 module MongoMapper
   module Acts

--- a/lib/acts_as_versioned.rb
+++ b/lib/acts_as_versioned.rb
@@ -47,7 +47,11 @@ module MongoMapper
             clone_attributes(self, rev)
             rev.version = version
 
-            self.versions << rev
+            begin
+              self.versions << rev
+              self.save
+            rescue BSON::InvalidDocument => e
+            end
           end
         end
 

--- a/lib/acts_as_versioned.rb
+++ b/lib/acts_as_versioned.rb
@@ -5,7 +5,7 @@ module MongoMapper
     module Versioned
       extend ActiveSupport::Concern
 
-      VERSION   = '0.1.3'
+      VERSION   = '0.1.4'
       CALLBACKS = [:save_version, :clear_old_versions]
 
       included do

--- a/lib/acts_as_versioned.rb
+++ b/lib/acts_as_versioned.rb
@@ -5,7 +5,7 @@ module MongoMapper
     module Versioned
       extend ActiveSupport::Concern
 
-      VERSION   = '0.1.1'
+      VERSION   = '0.1.0'
       CALLBACKS = [:save_version, :clear_old_versions]
 
       included do

--- a/lib/acts_as_versioned.rb
+++ b/lib/acts_as_versioned.rb
@@ -96,7 +96,7 @@ module MongoMapper
           end
 
           self.class.versioned_keys.each do |attribute|
-            new_model[attribute] = orig_model[attribute]
+            new_model[attribute] = orig_model[attribute].to_mongo
           end
         end
 

--- a/mongo_mapper_acts_as_versioned.gemspec
+++ b/mongo_mapper_acts_as_versioned.gemspec
@@ -1,4 +1,4 @@
-# require File.expand_path('../lib/acts_as_versioned', __FILE__)
+require File.expand_path('../lib/acts_as_versioned', __FILE__)
 
 Gem::Specification.new do |gem|
   gem.name        = 'mongo_mapper_acts_as_versioned'

--- a/mongo_mapper_acts_as_versioned.gemspec
+++ b/mongo_mapper_acts_as_versioned.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'rspec'
   gem.required_rubygems_version = '>= 1.3.6'
-  gem.add_dependency 'active_support'
+  # gem.add_dependency 'active_support'
 end

--- a/mongo_mapper_acts_as_versioned.gemspec
+++ b/mongo_mapper_acts_as_versioned.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'rspec'
   gem.required_rubygems_version = '>= 1.3.6'
+  gem.add_dependency 'active_support'
 end

--- a/mongo_mapper_acts_as_versioned.gemspec
+++ b/mongo_mapper_acts_as_versioned.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |gem|
   gem.files =
     Dir['{lib,spec}/**/*', 'LICENSE', 'README.md'] & `git ls-files -z`.split("\0")
 
-  gem.add_dependency 'active_support'
   gem.add_development_dependency 'rspec'
   gem.required_rubygems_version = '>= 1.3.6'
 end

--- a/mongo_mapper_acts_as_versioned.gemspec
+++ b/mongo_mapper_acts_as_versioned.gemspec
@@ -1,4 +1,4 @@
-require File.expand_path('../lib/acts_as_versioned', __FILE__)
+# require File.expand_path('../lib/acts_as_versioned', __FILE__)
 
 Gem::Specification.new do |gem|
   gem.name        = 'mongo_mapper_acts_as_versioned'

--- a/mongo_mapper_acts_as_versioned.gemspec
+++ b/mongo_mapper_acts_as_versioned.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |gem|
     Dir['{lib,spec}/**/*', 'LICENSE', 'README.md'] & `git ls-files -z`.split("\0")
 
   gem.add_development_dependency 'rspec'
-  gem.required_rubygems_version = '>= 1.3.6'
-  # gem.add_dependency 'active_support'
+  # gem.required_rubygems_version = '>= 1.3.6'
+  gem.add_dependency 'activesupport', '>= 3.0'
 end

--- a/mongo_mapper_acts_as_versioned.gemspec
+++ b/mongo_mapper_acts_as_versioned.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |gem|
   gem.files =
     Dir['{lib,spec}/**/*', 'LICENSE', 'README.md'] & `git ls-files -z`.split("\0")
 
+  gem.add_dependency 'active_support'
   gem.add_development_dependency 'rspec'
   gem.required_rubygems_version = '>= 1.3.6'
 end


### PR DESCRIPTION
I wrote a new method that checks for the Date type, which isn't supported by the MongoDB Ruby Driver, and calls Date.to_mongo(date) on it. This converts it to a mongo safe utc value. The tests were all passing when I ran them, so check it out and consider merging please.
